### PR TITLE
보드와 댓글의 반환값이 다른 부분 수정

### DIFF
--- a/boomerang/src/main/java/boomerang/board/dto/BoardListResponseDto.java
+++ b/boomerang/src/main/java/boomerang/board/dto/BoardListResponseDto.java
@@ -37,6 +37,7 @@ public class BoardListResponseDto {
         private String content;
         private AnonymousStatus anonymousStatus;
         private String writerEmail;
+        private String writerName;
         private Long likeCount;
         private Long commentCount;
 
@@ -53,6 +54,7 @@ public class BoardListResponseDto {
                     .content(content)  // 자른 content 사용
                     .anonymousStatus(board.getAnonymousStatus())
                     .writerEmail(board.getWriterEmail())
+                    .writerName(board.getMember().getNickname())
                     .likeCount(board.getLikeCount())
                     .commentCount(board.getCommentCount())
                     .build();

--- a/boomerang/src/main/java/boomerang/board/dto/BoardResponseDto.java
+++ b/boomerang/src/main/java/boomerang/board/dto/BoardResponseDto.java
@@ -20,6 +20,7 @@ public class BoardResponseDto {
     private String title;
     private String content;
     private String writerEmail;
+    private String writerName;
     private BoardType boardType;
     private Location location;
     private AnonymousStatus anonymousStatus;
@@ -38,6 +39,7 @@ public class BoardResponseDto {
         this.location = board.getLocation();
         this.anonymousStatus = board.getAnonymousStatus();
         this.writerEmail = board.getMember().getEmail();
+        this.writerName = board.getMember().getNickname();
         this.likeCount = board.getLikeCount();
         this.commentCount = board.getCommentCount();
         this.commentListResponseDto = commentListResponseDto;

--- a/boomerang/src/main/java/boomerang/comment/domain/Comment.java
+++ b/boomerang/src/main/java/boomerang/comment/domain/Comment.java
@@ -40,6 +40,10 @@ public class Comment {
         return author.getNickname();
     }
 
+    public String getAuthorEmail() {
+        return author.getEmail();
+    }
+
     @CreatedDate
     private LocalDateTime createdAt; //기본 업데이트 됨
 

--- a/boomerang/src/main/java/boomerang/comment/dto/CommentResponseDto.java
+++ b/boomerang/src/main/java/boomerang/comment/dto/CommentResponseDto.java
@@ -14,7 +14,8 @@ import java.time.LocalDateTime;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class CommentResponseDto {
     private Long id;                        //댓글아이디
-    private String authorName;              //작성자이름
+    private String writerEmail;              //작성자이름
+    private String writerName;
     private String text;                    //댓글내용
 
     //json 반환시 [2024-05-06 12:34:03]
@@ -23,19 +24,10 @@ public class CommentResponseDto {
     private boolean isEdited;               //수정여부
 
     //도메인을 기준으로 응답 객체를 만드는 부분
-    public CommentResponseDto (Comment comment, Boolean isAuthor) {
-        this.id = comment.getId();
-        this.authorName = comment.getAuthorName();
-        this.text = comment.getText();
-        this.isEdited = !comment.getCreatedAt().equals(comment.getUpdatedAt()); // 수정 여부 계산
-        this.lastModifiedAt = comment.getUpdatedAt() != null ? comment.getUpdatedAt() : comment.getCreatedAt(); //마지막으로 수정된 시간 제공
-    }
-
-
-    //도메인을 기준으로 응답 객체를 만드는 부분
     public CommentResponseDto (Comment comment) {
         this.id = comment.getId();
-        this.authorName = comment.getAuthorName();
+        this.writerEmail = comment.getAuthorEmail();
+        this.writerName = comment.getAuthorName();
         this.text = comment.getText();
         this.isEdited = !comment.getCreatedAt().equals(comment.getUpdatedAt()); // 수정 여부 계산
         this.lastModifiedAt = comment.getUpdatedAt() != null ? comment.getUpdatedAt() : comment.getCreatedAt(); //마지막으로 수정된 시간 제공

--- a/boomerang/src/main/java/boomerang/comment/service/CommentService.java
+++ b/boomerang/src/main/java/boomerang/comment/service/CommentService.java
@@ -80,12 +80,13 @@ public class CommentService {
     }
 
 
-    private CommentResponseDto createCommentResponseDto(Comment comment, boolean isUserLoggedIn, Member loginMember) {
-        if (!isUserLoggedIn) {
-            return new CommentResponseDto(comment); // 로그인하지 않은 경우
-        }
-        return new CommentResponseDto(comment, comment.isMemberCommentAuthor(loginMember)); // 로그인한 경우
-    }
+//    안쓰게 된 메서드
+//    private CommentResponseDto createCommentResponseDto(Comment comment, boolean isUserLoggedIn, Member loginMember) {
+//        if (!isUserLoggedIn) {
+//            return new CommentResponseDto(comment); // 로그인하지 않은 경우
+//        }
+//        return new CommentResponseDto(comment, comment.isMemberCommentAuthor(loginMember)); // 로그인한 경우
+//    }
 
     private PageRequest getPageRequest(CommentListRequestDto commentListRequestDto) {
         return PageRequest.of(

--- a/boomerang/src/main/java/boomerang/global/utils/JwtFilter.java
+++ b/boomerang/src/main/java/boomerang/global/utils/JwtFilter.java
@@ -79,9 +79,6 @@ public class JwtFilter extends OncePerRequestFilter {
 
         //MemberDetails에 회원 정보 객체 담기
         PrincipalDetails memberDetail = (PrincipalDetails) principalService.loadUserByEmail(email);
-        if (memberDetail.getMemberRole() == MemberRole.INCOMPLETE_USER) {
-            filterChain.doFilter(request, response);
-        }
 
         //스프링 시큐리티 인증 토큰 생성
         Authentication authToken = new UsernamePasswordAuthenticationToken(memberDetail, null, memberDetail.getAuthorities());


### PR DESCRIPTION
### 🛠️ 작업 사항
- [x] 버그 수정

댓글과 보드의 유저응답정보가 다른 부분을 둘다 이메일과 닉네임 모두 주는 방향으로 수정했음

