### PR TITLE
타입에 따른 메인단계 정보를 타입 enum이 아닌 전략 객체로 이동

### DIFF
--- a/boomerang/src/main/java/boomerang/global/response/ErrorCode.java
+++ b/boomerang/src/main/java/boomerang/global/response/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
     PROGRESS_SUB_MAIN_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, "PG008", "서브단계와 메인 단계가 적절하게 매칭되지 않습니다."),
     PROGRESS_NOT_INCLUDED_SUB(HttpStatus.NOT_FOUND, "PG009", "유저의 피해타입은 해당 세부단계를 가지고 있지 않습니다."),
     PROGRESS_NOT_INCLUDED_MAIN(HttpStatus.NOT_FOUND, "PG010", "유저의 피해타입은 해당 메인단계를 가지고 있지 않습니다."),
+    PROGRESS_MAIN_INVALID(HttpStatus.BAD_REQUEST, "PG011", "유저의 진행도 타입에 적절하지 않은 메인 단계입니다."),
     // Chat
     CHATROOM_DONT_HAS_OWNERSHIP_ERROR(HttpStatus.FORBIDDEN, "CH001", "채팅방에 대한 소유 권한이 없습니다."),
     CHATROOM_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "CH002", "해당 채팅방을 찾을 수 없습니다."),

--- a/boomerang/src/main/java/boomerang/progress/domain/ProgressType.java
+++ b/boomerang/src/main/java/boomerang/progress/domain/ProgressType.java
@@ -7,20 +7,18 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.util.List;
 
 public enum ProgressType {
-    A("A타입", "보험 미가입 / 계약 미해지", List.of(MainStepEnum.MAIN_STEP_1, MainStepEnum.MAIN_STEP_3)),
-    B("B타입", "보험 가입 / 계약 미해지", List.of(MainStepEnum.MAIN_STEP_2)),
-    C("C타입", "보험 미가입 / 계약 해지", List.of(MainStepEnum.MAIN_STEP_1)),
-    D("D타입", "보험 가입 / 계약 해지", List.of(MainStepEnum.MAIN_STEP_3));
+    A("A타입", "보험 미가입 / 계약 미해지"),
+    B("B타입", "보험 가입 / 계약 미해지"),
+    C("C타입", "보험 미가입 / 계약 해지"),
+    D("D타입", "보험 가입 / 계약 해지");
 
 
     private final String typeName;
     private final String description;
-    private final List<MainStepEnum> mainStepEnums;
 
-    ProgressType(String typeName, String description,  List<MainStepEnum> mainStepEnums) {
+    ProgressType(String typeName, String description) {
         this.typeName = typeName;
         this.description = description;
-        this.mainStepEnums = mainStepEnums;
     }
 
     public String getTypeName() {
@@ -31,9 +29,7 @@ public enum ProgressType {
         return description;
     }
 
-    public List<MainStepEnum> getMainStepEnums() {
-        return mainStepEnums;
-    }
+
 
     //DB에는 타입명만 올라갈 수 있도록 오버라이딩
     @Override

--- a/boomerang/src/main/java/boomerang/progress/service/ProgressService.java
+++ b/boomerang/src/main/java/boomerang/progress/service/ProgressService.java
@@ -65,9 +65,11 @@ public class ProgressService {
     //특정 메인 단계만 조회
     @Transactional(readOnly = true)
     public MainStepResponseDto getSubStepsByMainStep(PrincipalDetails principalDetails, MainStepEnum mainStepEnum) {
-        System.out.println("mainStepEnum = " + mainStepEnum.getMainStepName());
+
         Member member = memberService.getMemberByEmail(principalDetails.getMemberEmail());
         Progress progress = getProgressByMember(member);
+        ProgressStrategy progressStrategy = ProgressStrategyFactory.getStrategy(progress.getProgressType());
+        progressStrategy.isValidMainStepForProgressType(mainStepEnum);
 
         MainStep mainStep = getMainStepByEnum(progress, mainStepEnum);
 
@@ -81,6 +83,8 @@ public class ProgressService {
                                                SubStepEnum subStepEnum) {
         Member member = memberService.getMemberByEmail(principalDetails.getMemberEmail());
         Progress progress = getProgressByMember(member);
+        ProgressStrategy progressStrategy = ProgressStrategyFactory.getStrategy(progress.getProgressType());
+        progressStrategy.isValidMainStepForProgressType(mainStepEnum);
 
         MainStep mainStep = getMainStepByEnum(progress, mainStepEnum);
         SubStep subStep = getSubStepByEnum(mainStep, subStepEnum);
@@ -94,6 +98,9 @@ public class ProgressService {
 
         Member member = memberService.getMemberByEmail(principalDetails.getMemberEmail());
         Progress progress = getProgressByMember(member);
+        ProgressStrategy progressStrategy = ProgressStrategyFactory.getStrategy(progress.getProgressType());
+        progressStrategy.isValidMainStepForProgressType(mainStepEnum);
+
 
         MainStep mainStep = getMainStepByEnum(progress, mainStepEnum);
         SubStep subStep = getSubStepByEnum(mainStep, subStepEnum);
@@ -107,6 +114,9 @@ public class ProgressService {
     public SubStepResponseDto revertProgressToIncomplete(PrincipalDetails principalDetails, MainStepEnum mainStepEnum, SubStepEnum subStepEnum) {
         Member member = memberService.getMemberByEmail(principalDetails.getMemberEmail());
         Progress progress = getProgressByMember(member);
+        ProgressStrategy progressStrategy = ProgressStrategyFactory.getStrategy(progress.getProgressType());
+        progressStrategy.isValidMainStepForProgressType(mainStepEnum);
+
 
         MainStep mainStep = getMainStepByEnum(progress, mainStepEnum);
         SubStep subStep = getSubStepByEnum(mainStep, subStepEnum);

--- a/boomerang/src/main/java/boomerang/progress/util/ProgressAStrategy.java
+++ b/boomerang/src/main/java/boomerang/progress/util/ProgressAStrategy.java
@@ -1,19 +1,26 @@
 package boomerang.progress.util;
 
 
+import boomerang.global.exception.BusinessException;
+import boomerang.global.response.ErrorCode;
 import boomerang.member.domain.Member;
 import boomerang.progress.domain.*;
 
 import java.util.List;
+import java.util.Set;
 
 public class ProgressAStrategy implements ProgressStrategy {
+
+    private static final ProgressType progressType = ProgressType.A;
+    private static final Set<MainStepEnum> MAIN_STEPS =
+            Set.of(MainStepEnum.MAIN_STEP_1, MainStepEnum.MAIN_STEP_3);
+
+
     @Override
     public Progress makeProgress(Member member) {
-        ProgressType progressType = ProgressType.A;
-        List<MainStepEnum> mainStepEnumList = progressType.getMainStepEnums();
 
         Progress progress = new Progress(member, progressType);
-        List<MainStep> mainStepList = mainStepEnumList.stream()
+        List<MainStep> mainStepList = MAIN_STEPS.stream()
                 .map(
                         mainStepEnum ->
                         {
@@ -31,5 +38,12 @@ public class ProgressAStrategy implements ProgressStrategy {
         progress.registerMainStepList(mainStepList);
 
         return progress;
+    }
+
+    @Override
+    public void isValidMainStepForProgressType(MainStepEnum mainStepEnum) {
+        if (!MAIN_STEPS.contains(mainStepEnum)) {
+            throw new BusinessException(ErrorCode.PROGRESS_MAIN_INVALID);
+        }
     }
 }

--- a/boomerang/src/main/java/boomerang/progress/util/ProgressBStrategy.java
+++ b/boomerang/src/main/java/boomerang/progress/util/ProgressBStrategy.java
@@ -1,19 +1,22 @@
 package boomerang.progress.util;
 
+import boomerang.global.exception.BusinessException;
+import boomerang.global.response.ErrorCode;
 import boomerang.member.domain.Member;
 import boomerang.progress.domain.*;
 
 import java.util.List;
+import java.util.Set;
 
 public class ProgressBStrategy implements ProgressStrategy {
+    private static final ProgressType progressType = ProgressType.B;
+    private static final Set<MainStepEnum> MAIN_STEPS =
+            Set.of(MainStepEnum.MAIN_STEP_2);
 
     @Override
     public Progress makeProgress(Member member) {
-        ProgressType progressType = ProgressType.B;
-        List<MainStepEnum> mainStepEnumList = progressType.getMainStepEnums();
-
         Progress progress = new Progress(member, progressType);
-        List<MainStep> mainStepList = mainStepEnumList.stream()
+        List<MainStep> mainStepList = MAIN_STEPS.stream()
                 .map(
                         mainStepEnum ->
                         {
@@ -32,4 +35,12 @@ public class ProgressBStrategy implements ProgressStrategy {
 
         return progress;
     }
+
+    @Override
+    public void isValidMainStepForProgressType(MainStepEnum mainStepEnum) {
+        if (!MAIN_STEPS.contains(mainStepEnum)) {
+            throw new BusinessException(ErrorCode.PROGRESS_MAIN_INVALID);
+        }
+    }
+
 }

--- a/boomerang/src/main/java/boomerang/progress/util/ProgressCStrategy.java
+++ b/boomerang/src/main/java/boomerang/progress/util/ProgressCStrategy.java
@@ -1,19 +1,24 @@
 package boomerang.progress.util;
 
+import boomerang.global.exception.BusinessException;
+import boomerang.global.response.ErrorCode;
 import boomerang.member.domain.Member;
 import boomerang.progress.domain.*;
 
 import java.util.List;
+import java.util.Set;
 
 public class ProgressCStrategy implements ProgressStrategy {
 
+    private static final ProgressType progressType = ProgressType.C;
+    private static final Set<MainStepEnum> MAIN_STEPS =
+            Set.of(MainStepEnum.MAIN_STEP_1);
+
     @Override
     public Progress makeProgress(Member member) {
-        ProgressType progressType = ProgressType.C;
-        List<MainStepEnum> mainStepEnumList = progressType.getMainStepEnums();
 
         Progress progress = new Progress(member, progressType);
-        List<MainStep> mainStepList = mainStepEnumList.stream()
+        List<MainStep> mainStepList = MAIN_STEPS.stream()
                 .map(
                         mainStepEnum ->
                         {
@@ -31,5 +36,12 @@ public class ProgressCStrategy implements ProgressStrategy {
         progress.registerMainStepList(mainStepList);
 
         return progress;
+    }
+
+    @Override
+    public void isValidMainStepForProgressType(MainStepEnum mainStepEnum) {
+        if (!MAIN_STEPS.contains(mainStepEnum)) {
+            throw new BusinessException(ErrorCode.PROGRESS_MAIN_INVALID);
+        }
     }
 }

--- a/boomerang/src/main/java/boomerang/progress/util/ProgressDStrategy.java
+++ b/boomerang/src/main/java/boomerang/progress/util/ProgressDStrategy.java
@@ -1,19 +1,22 @@
 package boomerang.progress.util;
 
+import boomerang.global.exception.BusinessException;
+import boomerang.global.response.ErrorCode;
 import boomerang.member.domain.Member;
 import boomerang.progress.domain.*;
 
 import java.util.List;
+import java.util.Set;
 
 public class ProgressDStrategy implements ProgressStrategy {
 
+    private static final ProgressType progressType = ProgressType.D;
+    private static final Set<MainStepEnum> MAIN_STEPS =
+            Set.of(MainStepEnum.MAIN_STEP_3);
     @Override
     public Progress makeProgress(Member member) {
-        ProgressType progressType = ProgressType.D;
-        List<MainStepEnum> mainStepEnumList = progressType.getMainStepEnums();
-
         Progress progress = new Progress(member, progressType);
-        List<MainStep> mainStepList = mainStepEnumList.stream()
+        List<MainStep> mainStepList = MAIN_STEPS.stream()
                 .map(
                         mainStepEnum ->
                         {
@@ -31,5 +34,12 @@ public class ProgressDStrategy implements ProgressStrategy {
         progress.registerMainStepList(mainStepList);
 
         return progress;
+    }
+
+    @Override
+    public void isValidMainStepForProgressType(MainStepEnum mainStepEnum) {
+        if (!MAIN_STEPS.contains(mainStepEnum)) {
+            throw new BusinessException(ErrorCode.PROGRESS_MAIN_INVALID);
+        }
     }
 }

--- a/boomerang/src/main/java/boomerang/progress/util/ProgressStrategy.java
+++ b/boomerang/src/main/java/boomerang/progress/util/ProgressStrategy.java
@@ -6,4 +6,5 @@ import boomerang.progress.domain.*;
 
 public interface ProgressStrategy {
     Progress makeProgress(Member member);
+    void isValidMainStepForProgressType(MainStepEnum mainStepEnum);
 }


### PR DESCRIPTION
### ️️ 구현 사항
- 타입마다 메인 단계정보를 enum에 가지고 있던 부분을 전략 객체로 이동
_예시코드_
```java
public class ProgressDStrategy implements ProgressStrategy {

    private static final ProgressType progressType = ProgressType.D;
    private static final Set<MainStepEnum> MAIN_STEPS =
            Set.of(MainStepEnum.MAIN_STEP_3);
    @Override
    public Progress makeProgress(Member member) {
        Progress progress = new Progress(member, progressType);
        List<MainStep> mainStepList = MAIN_STEPS.stream()
                .map(
                        mainStepEnum ->
                        {
                            MainStep mainStep = new MainStep(mainStepEnum,progress);
                            List<SubStep> subStepList = mainStepEnum.getSubStepEnumList()
                                    .stream()
                                    .map(subStepEnum -> new SubStep(mainStep, subStepEnum)).toList();

                            mainStep.registerSubStepList(subStepList);

                            return mainStep;
                        })
                .toList();

        progress.registerMainStepList(mainStepList);

        return progress;
    }
```
   
